### PR TITLE
add DFS status key, same at SDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Watch `/config/home-assistant.log`, which is accessible from the frontend via De
 "BR" == Bonnet removed
 "P" == Unit is Paused
 "OFF" == Unit is turned off
-"SDF" == Drawer is completely full and will not cycle. 
+"SDF" == Drawer is completely full and will not cycle.
+"DFS" == Drawer is completely full and will not cycle. 
 ```
 
 ### Commands

--- a/litter_robot/sensor.py
+++ b/litter_robot/sensor.py
@@ -23,7 +23,8 @@ LITTER_ROBOT_UNIT_STATUS = {
   'BR' : 'Bonnet Removed',
   'P'  : 'Paused',
   'OFF': 'Off',
-  'SDF': 'Not Ready - Drawer Full'
+  'SDF': 'Not Ready - Drawer Full',
+  'DFS': 'Not Ready - Drawer Full'
 }
 SENSOR_PREFIX = 'Litter-Robot '
 


### PR DESCRIPTION
fixes error:

```
Traceback (most recent call last):
   File "/usr/src/app/homeassistant/helpers/entity_platform.py", line 365, in _async_add_entity
     await entity.async_update_ha_state()
   File "/usr/src/app/homeassistant/helpers/entity.py", line 225, in async_update_ha_state
     self._async_write_ha_state()
   File "/usr/src/app/homeassistant/helpers/entity.py", line 248, in _async_write_ha_state
     state = self.state
   File "/config/custom_components/litter_robot/sensor.py", line 74, in state
     return LITTER_ROBOT_UNIT_STATUS[unit_status]
 KeyError: 'DFS'
```

DFS key mentioned a few times here: https://community.smartthings.com/t/litter-robot-connect/106882/16

"SDF" mentioned once but haven't seen it myself. Typo? Or old change? 🤷
