### PR TITLE
fix(polling): Throttling removed for HA ~>0.111

### DIFF
--- a/custom_components/litter_robot/__init__.py
+++ b/custom_components/litter_robot/__init__.py
@@ -27,6 +27,8 @@ LITTER_ROBOTS = 'litter_robots'
 
 ATTR_CYCLE_COUNT = 'cycleCount'
 
+SCAN_INTERVAL = timedelta(seconds=120)
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
@@ -151,7 +153,6 @@ class LitterRobotHub:
             _LOGGER.error("Unable to connect to Litter-Robot API")
             return False
 
-    @Throttle(timedelta(seconds=120))
     def update_robots(self):
         """Update the robot states."""
         self._hass.data[DOMAIN][LITTER_ROBOTS] = self._my_litter_robots.robots()

--- a/custom_components/litter_robot/sensor.py
+++ b/custom_components/litter_robot/sensor.py
@@ -5,6 +5,7 @@ https://home-assistant.io/components/
 """
 
 import logging
+from datetime import timedelta
 from homeassistant.helpers.entity import Entity
 
 DEPENDENCIES = ['litter_robot']
@@ -31,6 +32,7 @@ SENSOR_PREFIX = 'Litter-Robot '
 
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVAL = timedelta(seconds=120)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Litter-Robot sensors."""


### PR DESCRIPTION
Fixes #18.

As a next step, proper data polling should be done with [the data update coordinator](https://developers.home-assistant.io/docs/integration_fetching_data).