### PR TITLE
feat(commands): Reset drawer, to let the robot know the tray has been emptied

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ switch:
         turn_on:
           service: litter_robot.cycle
         turn_off:
+      litter_robot_reset_drawer:
+        friendly_name: "Tesla Meowdel S Reset Drawer"
+        value_template: "{{ is_state('sensor.litter_robot_tesla_meowdel_s_status', 'Clean Cycling') }}"
+        icon_template: "mdi:repeat"
+        turn_on:
+          service: litter_robot.reset_drawer
+        turn_off:
 ```
 
 ### Finishing setup
@@ -64,12 +71,12 @@ Edit `/config/groups.yaml`. For a robot nicknamed "Tesla Meowdel S":
 
 ```yaml
 Tesla Meowdel S:
-  control: hidden
   entities:
     - sensor.litter_robot_tesla_meowdel_s_status
     - sensor.litter_robot_tesla_meowdel_s_waste
     - switch.litter_robot_cycle
     - switch.litter_robot_nightlight
+    - switch.litter_robot_reset_drawer
 ```
 
 Then reload Groups config. This is easiest done with the frontend Configuration -> General -> Configuration reloading -> Reload groups.
@@ -234,8 +241,3 @@ body:
 ```
 
 Response is one full robot entity.
-
-## TODO
-
-- [More sensors](https://community.smartthings.com/t/litter-robot-connect/106882/19)
-  - Mark drawer empty

--- a/custom_components/litter_robot/__init__.py
+++ b/custom_components/litter_robot/__init__.py
@@ -48,6 +48,10 @@ SERVICE_CYCLE_SCHEMA = vol.Schema(
     {vol.Optional('litter_robot_id'): cv.string}
 )
 
+RESET_DRAWER_SCHEMA = vol.Schema(
+    {vol.Optional('litter_robot_id'): cv.string}
+)
+
 
 async def async_setup(hass: HomeAssistant, config: Config):
     """Set up the Litter-Robot component."""
@@ -83,12 +87,19 @@ async def async_setup(hass: HomeAssistant, config: Config):
         await asyncio.sleep(15)
         await coordinator.async_request_refresh()
 
+    async def async_reset_drawer_handler(call):
+        await litter_robot.async_reset_drawer(call.data or list(litter_robot.robots.keys())[0])
+        await asyncio.sleep(15)
+        await coordinator.async_request_refresh()
+
     hass.services.async_register(DOMAIN, 'nightlight_turn_on',
                                  async_nightlight_on_handler, SERVICE_NIGHTLIGHT_TURN_ON_SCHEMA)
     hass.services.async_register(DOMAIN, 'nightlight_turn_off',
                                  async_nightlight_off_handler, SERVICE_NIGHTLIGHT_TURN_OFF_SCHEMA)
     hass.services.async_register(
         DOMAIN, 'cycle', async_cycle_start_handler, SERVICE_CYCLE_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, 'reset_drawer', async_reset_drawer_handler, RESET_DRAWER_SCHEMA)
     return True
 
 

--- a/custom_components/litter_robot/litter_robot.py
+++ b/custom_components/litter_robot/litter_robot.py
@@ -38,6 +38,20 @@ class LitterRobot:
     async def async_cycle_start(self, robot_id):
         await self.async_send_command(robot_id, '<C')
 
+    async def async_reset_drawer(self, robot_id):
+        try:
+            await self._async_login()
+            async with aiohttp.ClientSession() as session:
+                async with session.patch('https://v2.api.whisker.iothings.site/users/' + self._user_id + '/robots/' + robot_id,
+                                         json={'cycleCount': '0',
+                                               'cycleCapacity': '46', 'cyclesAfterDrawerFull': '0'},
+                                         headers={'x-api-key': X_API_KEY, 'Authorization': self._auth_token}) as r:
+                    if r.status >= 300:
+                        _LOGGER.error(
+                            "[reset drawer] Unexpected response: %s", r)
+        except Exception as ex:
+            _LOGGER.error("[reset drawer] Unexpected exception: %s", ex)
+
     async def async_send_command(self, robot_id, command):
         try:
             await self._async_login()

--- a/custom_components/litter_robot/sensor.py
+++ b/custom_components/litter_robot/sensor.py
@@ -54,6 +54,11 @@ class LitterRobotEntity(Entity):
         self._device_info = device_info
 
     @property
+    def device_state_attributes(self):
+        """Return the device_info of the device."""
+        return self._device_info
+
+    @property
     def should_poll(self):
         """Return the polling requirement of the entity."""
         return False

--- a/custom_components/litter_robot/services.yaml
+++ b/custom_components/litter_robot/services.yaml
@@ -23,3 +23,11 @@ cycle:
     litter_robot_id:
       description: ID from the Litter Robot API. Get value from the StatusSensor entity state. Defaults to first robot in API response.
       example: "a00bb111cccca"
+
+reset_drawer:
+  description: >
+    Reset drawer
+  fields:
+    litter_robot_id:
+      description: ID from the Litter Robot API. Get value from the StatusSensor entity state. Defaults to first robot in API response.
+      example: "a00bb111cccca"


### PR DESCRIPTION
Sends a `patch` command with `cycleCount`, `cycleCapacity` and `cyclesAfterDrawerFull` as captured from the iOS app.

Also fixes missing device_state_attributes from #20 that make it easy to discover id of litter robots in the Developer Tools -> States page.