### PR TITLE
feat(services): Sleep mode can be enabled/disabled by service commands.

### DIFF
--- a/custom_components/litter_robot/litter_robot.py
+++ b/custom_components/litter_robot/litter_robot.py
@@ -42,6 +42,12 @@ class LitterRobot:
     async def async_cycle_start(self, robot_id):
         await self.async_send_command(robot_id, '<C')
 
+    async def async_sleep_enable(self, robot_id, hours, minutes, seconds):
+        await self.async_send_command(robot_id, '<S1{:02d}:{:02d}:{:02d}'.format(hours, minutes, seconds))
+
+    async def async_sleep_disable(self, robot_id):
+        await self.async_send_command(robot_id, '<S0')
+
     async def async_reset_drawer(self, robot_id):
         async def async_run():
             await self._async_login()

--- a/custom_components/litter_robot/services.yaml
+++ b/custom_components/litter_robot/services.yaml
@@ -5,7 +5,7 @@ nightlight_turn_on:
     Turn nightlight on
   fields:
     litter_robot_id:
-      description: ID from the Litter Robot API. Get value from the StatusSensor entity state. Defaults to first robot in API response.
+      description: ID from the Litter Robot API. Get value from the any entity state. Defaults to first robot in API response.
       example: "a00bb111cccca"
 
 nightlight_turn_off:
@@ -13,7 +13,7 @@ nightlight_turn_off:
     Turn nightlight off
   fields:
     litter_robot_id:
-      description: ID from the Litter Robot API. Get value from the StatusSensor entity state. Defaults to first robot in API response.
+      description: ID from the Litter Robot API. Get value from the any entity state. Defaults to first robot in API response.
       example: "a00bb111cccca"
 
 cycle:
@@ -21,7 +21,7 @@ cycle:
     Start cleaning cycle
   fields:
     litter_robot_id:
-      description: ID from the Litter Robot API. Get value from the StatusSensor entity state. Defaults to first robot in API response.
+      description: ID from the Litter Robot API. Get value from the any entity state. Defaults to first robot in API response.
       example: "a00bb111cccca"
 
 reset_drawer:
@@ -29,5 +29,28 @@ reset_drawer:
     Reset drawer
   fields:
     litter_robot_id:
-      description: ID from the Litter Robot API. Get value from the StatusSensor entity state. Defaults to first robot in API response.
+      description: ID from the Litter Robot API. Get value from the any entity state. Defaults to first robot in API response.
       example: "a00bb111cccca"
+
+sleep_enable:
+  description: >
+    Enables 8 hour sleep timeout starting at provided offset. E.g. 0:00:00 starts sleep now, 8:00:00 means sleep mode just finished at the current time.
+  fields:
+    litter_robot_id:
+      description: ID from the Litter Robot API. Get value from any entity state. Defaults to first robot in API response.
+    h:
+      description: Hours since start of sleep mode. 0 = started this hour, 8 = ended this hour, 23 = starting within the next hour.
+      example: 0
+    min:
+      description: Minutes within hour since start of sleep mode.
+      example: 0
+    s:
+      description: Seconds within minute since start of sleep mode.
+      example: 0
+
+sleep_disable:
+  description: >
+    Disables sleep mode.
+  fields:
+    litter_robot_id:
+      description: ID from the Litter Robot API. Get value from any entity state. Defaults to first robot in API response.


### PR DESCRIPTION
Completes #27 

Sending the `litter_robot.sleep_enable` a payload of the following from the Developer Tools/Services tab enables the 8 hour sleep mode at the current time.

```json
{
  "h": 0,
  "min": 0,
  "s": 0
}
```

This payload sets it to just be finished, so it will enter sleep mode again in 16 hours.
```json
{
  "h": 8,
  "min": 0,
  "s": 0
}
```

The service `litter_robot.sleep_disable` turns off sleep mode regardless of the set time.