### PR TITLE
fix(manifest): Specify CalVer-format integration version

### DIFF
--- a/custom_components/litter_robot/manifest.json
+++ b/custom_components/litter_robot/manifest.json
@@ -6,6 +6,7 @@
   "codeowners": [
     "@joshjcarrier"
   ],
+  "version": "2021.5.0",
   "requirements": [],
   "homeassistant": "0.111.0"
 }


### PR DESCRIPTION
Fixes #43 as specifying a version is now required for custom integration loading.