### PR TITLE
Add HACS metadata and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ The `litter-robot` component offers integration with the [Litter-Robot](https://
 
 ## Install
 
-Load this component by copying the custom_components/litter_robot directory and its contents to the custom_components directory in your Home Assistant's configuration directory, typically `/config/custom_components`, but may be [elsewhere](https://www.home-assistant.io/docs/configuration/) depending on your installation. This is easiest with the Samba share add-on.  Alternatively, from a [terminal](https://github.com/home-assistant/addons/blob/master/ssh/DOCS.md) run the following:
+### HACS
+
+1. In Home Assistant, open HACS.
+2. Go to the menu in the top right and select "Custom repositories".
+3. Add `https://github.com/joshjcarrier/homeassistant-litter-robot` as an `Integration` repository.
+4. Install `Litter-Robot` from HACS.
+5. Restart Home Assistant.
+
+### Manual
+
+Load this component by copying the custom_components/litter_robot directory and its contents to the custom_components directory in your Home Assistant's configuration directory, typically `/config/custom_components`, but may be [elsewhere](https://www.home-assistant.io/docs/configuration/) depending on your installation. This is easiest with the Samba share add-on. Alternatively, from a [terminal](https://github.com/home-assistant/addons/blob/master/ssh/DOCS.md) run the following:
 ```
 git clone --depth=1 https://github.com/joshjcarrier/homeassistant-litter-robot.git
 cp -r homeassistant-litter-robot/custom_components/litter_robot /config/custom_components/

--- a/custom_components/litter_robot/manifest.json
+++ b/custom_components/litter_robot/manifest.json
@@ -1,11 +1,14 @@
 {
   "domain": "litter_robot",
-  "name": "litter_robot",
+  "name": "Litter-Robot",
   "documentation": "https://github.com/joshjcarrier/homeassistant-litter-robot",
   "dependencies": [],
   "codeowners": [
     "@joshjcarrier"
   ],
+  "integration_type": "hub",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/joshjcarrier/homeassistant-litter-robot/issues",
   "version": "2021.5.0",
   "requirements": [],
   "homeassistant": "0.111.0"

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,3 @@
+{
+  "name": "Litter-Robot"
+}


### PR DESCRIPTION
## Summary
- add a repo-root `hacs.json` so HACS recognizes the repository as a custom integration
- update `manifest.json` with HACS-facing metadata, including a friendlier integration name and issue tracker
- add README instructions for installing the integration through HACS while keeping the manual install path documented

## Validation
- validated `custom_components/litter_robot/manifest.json` with `jq`
- validated `hacs.json` with `jq`
- confirmed the integration works with a HACS install
- no runtime Python behavior was changed in this PR

Thanks for taking a look.

Codex helped implement this change and generate this PR.